### PR TITLE
Critical Bug - OAuth Token Refresh

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 	<groupId>io.github.mulesoft-forge</groupId>
 	<artifactId>mule-idp-connector</artifactId>
 	<packaging>mule-extension</packaging>
-	<version>1.0.5</version>
+	<version>1.0.6</version>
 
 	<name>IDP Connector</name>
 	<description>A Mule extension that provides functionality for Intelligent Document Processing</description>

--- a/src/main/java/org/mule/extension/idp/internal/connection/IDPConnection.java
+++ b/src/main/java/org/mule/extension/idp/internal/connection/IDPConnection.java
@@ -103,8 +103,7 @@ public class IDPConnection {
     public CompletableFuture<HttpResponse> sendRequestNonBlocking(Consumer<HttpRequestBuilder> httpRequestBuilderConsumer,
                                                                   String uri,
                                                                   HttpConstants.Method method,
-                                                                  IDPAuthentication authentication,
-                                                                  String accessTokenIfAuthenticationIsOAuth) {
+                                                                  IDPAuthentication authentication) {
 
         HttpRequestBuilder builder = HttpRequest.builder();
 
@@ -112,41 +111,29 @@ public class IDPConnection {
             httpRequestBuilderConsumer.accept(builder);
         }
 
-        HttpRequest request = null;
+        HttpRequest request = builder.method(method).uri(uri).build();
         HttpRequestOptions options = null;
 
         if (authentication == IDPAuthentication.BASIC_AUTH) {
             options = HttpRequestOptions.builder()
                     .authentication(httpAuthentication)
                     .build();
-            request = builder.method(method)
-                    .uri(uri)
-                    .build();
-
             return httpClient.sendAsync(request, options);
 
         } else if (authentication == IDPAuthentication.OAUTH) {
-            request = builder.method(method)
-                    .uri(uri)
-                    .addHeader(AUTHORIZATION, "Bearer " + accessTokenIfAuthenticationIsOAuth)
+            options = HttpRequestOptions.builder()
+                    .authentication(httpAuthentication)
                     .build();
-
-            return httpClient.sendAsync(request);
-
+            return httpClient.sendAsync(request, options);
         } else {
-            request = builder.method(method)
-                    .uri(uri)
-                    .build();
+            return httpClient.sendAsync(request);
         }
-
-        return httpClient.sendAsync(request);
     }
 
     public HttpResponse sendRequestBlocking(Consumer<HttpRequestBuilder> httpRequestBuilderConsumer,
                                             String uri,
                                             HttpConstants.Method method,
-                                            IDPAuthentication authentication,
-                                            String accessTokenIfAuthenticationIsOAuth) throws Throwable {
+                                            IDPAuthentication authentication) throws Throwable {
 
         HttpRequestBuilder builder = HttpRequest.builder();
 
@@ -154,34 +141,24 @@ public class IDPConnection {
             httpRequestBuilderConsumer.accept(builder);
         }
 
-        HttpRequest request = null;
+        HttpRequest request = builder.method(method).uri(uri).build();
         HttpRequestOptions options = null;
 
         if (authentication == IDPAuthentication.BASIC_AUTH) {
             options = HttpRequestOptions.builder()
                     .authentication(httpAuthentication)
                     .build();
-            request = builder.method(method)
-                    .uri(uri)
-                    .build();
-
             return httpClient.send(request, options);
 
         } else if (authentication == IDPAuthentication.OAUTH) {
-            request = builder.method(method)
-                    .uri(uri)
-                    .addHeader(AUTHORIZATION, "Bearer " + accessTokenIfAuthenticationIsOAuth)
+            options = HttpRequestOptions.builder()
+                    .authentication(httpAuthentication)
                     .build();
-
-            return httpClient.send(request);
+            return httpClient.send(request, options);
 
         } else {
-            request = builder.method(method)
-                    .uri(uri)
-                    .build();
+            return httpClient.send(request);
         }
-
-        return httpClient.send(request);
     }
 
     public void invalidate() {

--- a/src/main/java/org/mule/extension/idp/internal/connection/provider/IDPConnectionProvider.java
+++ b/src/main/java/org/mule/extension/idp/internal/connection/provider/IDPConnectionProvider.java
@@ -141,7 +141,7 @@ public class IDPConnectionProvider implements CachedConnectionProvider<IDPConnec
 
         try {
             HttpResponse httpResponse = connection.sendRequestBlocking(requestBuilder -> {
-            }, uri, HttpConstants.Method.GET, IDPAuthentication.BASIC_AUTH, "");
+            }, uri, HttpConstants.Method.GET, IDPAuthentication.BASIC_AUTH);
 
             int statusCode = httpResponse.getStatusCode();
             String reason = httpResponse.getReasonPhrase();

--- a/src/main/java/org/mule/extension/idp/internal/extension/IDPConnector.java
+++ b/src/main/java/org/mule/extension/idp/internal/extension/IDPConnector.java
@@ -20,11 +20,11 @@ import org.mule.sdk.api.annotation.MinMuleVersion;
 
 import static org.mule.sdk.api.meta.JavaVersion.*;
 /**
- * MuleSoft IDP Universal Connector
+ * MuleSoftForge IDP Universal Connector
  *
  * @author Open Source
  */
-@Extension(name="MuleSoft IDP", category = Category.COMMUNITY)
+@Extension(name="MuleSoftForge IDP", category = Category.COMMUNITY)
 @ErrorTypes(IDPError.class)
 @Xml(prefix ="mule-idp")
 @Configurations(IDPConfiguration.class)

--- a/src/main/java/org/mule/extension/idp/internal/operation/IDPPlatformOperations.java
+++ b/src/main/java/org/mule/extension/idp/internal/operation/IDPPlatformOperations.java
@@ -69,7 +69,7 @@ public class IDPPlatformOperations {
                     if (pageable.getSort() != null) {
                         requestBuilder.addQueryParam("sort", String.valueOf(pageable.getSort()));
                     }
-                }, uri, HttpConstants.Method.GET, IDPAuthentication.BASIC_AUTH, "")
+                }, uri, HttpConstants.Method.GET, IDPAuthentication.BASIC_AUTH)
                 .whenCompleteAsync(IDPOperationsUtils.createCompletionHandler(completionCallback, uri));
     }
 
@@ -103,7 +103,7 @@ public class IDPPlatformOperations {
                     if (pageable.getSort() != null) {
                         requestBuilder.addQueryParam("sort", String.valueOf(pageable.getSort()));
                     }
-                }, uri, HttpConstants.Method.GET, IDPAuthentication.BASIC_AUTH, "")
+                }, uri, HttpConstants.Method.GET, IDPAuthentication.BASIC_AUTH)
                 .whenCompleteAsync(IDPOperationsUtils.createCompletionHandler(completionCallback, uri));
     }
 
@@ -129,7 +129,7 @@ public class IDPPlatformOperations {
 
         String uri = connection.getPlatformBaseUrl() + IDPOperationsUtils.createEndpoint(PLATFORM_BASE + PLATFORM_IDP_RETRIEVE_ACTION_VERSION, uriParameters);
 
-        connection.sendRequestNonBlocking(requestBuilder -> {}, uri, HttpConstants.Method.GET, IDPAuthentication.BASIC_AUTH, "")
+        connection.sendRequestNonBlocking(requestBuilder -> {}, uri, HttpConstants.Method.GET, IDPAuthentication.BASIC_AUTH)
                 .whenCompleteAsync(IDPOperationsUtils.createCompletionHandler(completionCallback, uri));
     }
 
@@ -154,7 +154,7 @@ public class IDPPlatformOperations {
 
         String uri = connection.getPlatformBaseUrl() + IDPOperationsUtils.createEndpoint(PLATFORM_BASE + PLATFORM_IDP_RETRIEVE_ACTION_DETAIL, uriParameters);
 
-        connection.sendRequestNonBlocking(requestBuilder -> {}, uri, HttpConstants.Method.GET, IDPAuthentication.BASIC_AUTH, "")
+        connection.sendRequestNonBlocking(requestBuilder -> {}, uri, HttpConstants.Method.GET, IDPAuthentication.BASIC_AUTH)
                 .whenCompleteAsync(IDPOperationsUtils.createCompletionHandler(completionCallback, uri));
     }
 
@@ -177,7 +177,7 @@ public class IDPPlatformOperations {
 
         String uri = connection.getPlatformBaseUrl() + IDPOperationsUtils.createEndpoint(PLATFORM_BASE + PLATFORM_IDP_LIST_ACTION_REVIEWERS, uriParameters);
 
-        connection.sendRequestNonBlocking(requestBuilder -> {}, uri, HttpConstants.Method.GET, IDPAuthentication.BASIC_AUTH, "")
+        connection.sendRequestNonBlocking(requestBuilder -> {}, uri, HttpConstants.Method.GET, IDPAuthentication.BASIC_AUTH)
                 .whenCompleteAsync(IDPOperationsUtils.createCompletionHandler(completionCallback, uri));
     }
 
@@ -204,7 +204,7 @@ public class IDPPlatformOperations {
         connection.sendRequestNonBlocking(requestBuilder -> {
                     requestBuilder.addHeader("Content-Type", "application/json");
                     requestBuilder.entity(new InputStreamHttpEntity(contents.getValue()));
-                }, uri, HttpConstants.Method.PATCH, IDPAuthentication.BASIC_AUTH, "")
+                }, uri, HttpConstants.Method.PATCH, IDPAuthentication.BASIC_AUTH)
                 .whenCompleteAsync(IDPOperationsUtils.createCompletionHandler(completionCallback, uri));
     }
 }

--- a/src/main/java/org/mule/extension/idp/internal/operation/IDPServiceOperations.java
+++ b/src/main/java/org/mule/extension/idp/internal/operation/IDPServiceOperations.java
@@ -93,7 +93,7 @@ public class IDPServiceOperations {
 
             requestBuilder.entity(new MultipartHttpEntity(multiPartsFormData));
 
-        }, uri, HttpConstants.Method.POST, IDPAuthentication.OAUTH, connection.getClientCredentialsState().getAccessToken())
+        }, uri, HttpConstants.Method.POST, IDPAuthentication.OAUTH)
         .whenCompleteAsync(IDPOperationsUtils.createCompletionHandler(completionCallback, uri));
     }
 
@@ -119,7 +119,7 @@ public class IDPServiceOperations {
         connection.sendRequestNonBlocking(requestBuilder -> {
                     requestBuilder.addQueryParam("valueOnly", String.valueOf(valueOnly));
 
-                }, uri, HttpConstants.Method.GET, IDPAuthentication.OAUTH, connection.getClientCredentialsState().getAccessToken())
+                }, uri, HttpConstants.Method.GET, IDPAuthentication.OAUTH)
                 .whenCompleteAsync(IDPOperationsUtils.createCompletionHandler(completionCallback, uri));
     }
 
@@ -143,7 +143,7 @@ public class IDPServiceOperations {
                     if (pageable.getSize() > 0) {
                         requestBuilder.addQueryParam("size", String.valueOf(pageable.getSize()));
                     }
-                }, uri, HttpConstants.Method.GET, IDPAuthentication.BASIC_AUTH, "")
+                }, uri, HttpConstants.Method.GET, IDPAuthentication.BASIC_AUTH)
                 .whenCompleteAsync(IDPOperationsUtils.createCompletionHandler(completionCallback, uri));
     }
 
@@ -164,7 +164,7 @@ public class IDPServiceOperations {
         String uri = connection.getServiceBaseUrl() + IDPOperationsUtils.createEndpoint(IDP_BASE + IDP_RETRIEVE_REVIEW_TASK, uriParameters);
 
         connection.sendRequestNonBlocking(requestBuilder -> {
-                }, uri, HttpConstants.Method.GET, IDPAuthentication.BASIC_AUTH, "")
+                }, uri, HttpConstants.Method.GET, IDPAuthentication.BASIC_AUTH)
                 .whenCompleteAsync(IDPOperationsUtils.createCompletionHandler(completionCallback, uri));
     }
 
@@ -184,7 +184,7 @@ public class IDPServiceOperations {
         String uri = connection.getServiceBaseUrl() + IDPOperationsUtils.createEndpoint(IDP_BASE + IDP_DELETE_REVIEW_TASK, uriParameters);
 
         connection.sendRequestNonBlocking(requestBuilder -> {
-                }, uri, HttpConstants.Method.DELETE, IDPAuthentication.BASIC_AUTH, "")
+                }, uri, HttpConstants.Method.DELETE, IDPAuthentication.BASIC_AUTH)
                 .whenCompleteAsync(IDPOperationsUtils.createCompletionHandler(completionCallback, uri));
     }
 
@@ -208,7 +208,7 @@ public class IDPServiceOperations {
         connection.sendRequestNonBlocking(requestBuilder -> {
                     requestBuilder.addHeader("Content-Type", "application/json");
                     requestBuilder.entity(new InputStreamHttpEntity(contents.getValue()));
-                }, uri, HttpConstants.Method.PATCH, IDPAuthentication.BASIC_AUTH, "")
+                }, uri, HttpConstants.Method.PATCH, IDPAuthentication.BASIC_AUTH)
                 .whenCompleteAsync(IDPOperationsUtils.createCompletionHandler(completionCallback, uri));
     }
 

--- a/src/main/java/org/mule/extension/idp/internal/operation/utils/IDPOperationsUtils.java
+++ b/src/main/java/org/mule/extension/idp/internal/operation/utils/IDPOperationsUtils.java
@@ -30,7 +30,7 @@ public class IDPOperationsUtils {
                 int statusCode = httpResponse.getStatusCode();
                 String reason = httpResponse.getReasonPhrase();
                 if (statusCode >= 400) {
-                    completionCallback.error(new IDPHttpException(createHttpResponseMessage("IDP Error Occured", reason, statusCode, uri), IDPError.CONNECTIVITY) );
+                    completionCallback.error(new IDPHttpException(createHttpResponseMessage("IDP Error Occurred", reason, statusCode, uri), IDPError.CONNECTIVITY) );
                 } else {
                     completionCallback.success(Result.<InputStream, Void>builder().output(httpResponse.getEntity().getContent())
                             .mediaType(APPLICATION_JSON)


### PR DESCRIPTION
{
"message": "IDP Error Occured",
"reason": "Unauthorized",
"code": 401,
"resource": "https://idp-rt.us-east-1.anypoint.mulesoft.com/api/v1/organizations/eca25329-9592-4ff1-9054-1b08d103b991/actions/5b7ab176-1a74-4b5d-95a2-0c4fe62c8648/versions/1.1.0/executions" }

The core problem was an architectural mismatch in your MuleSoft connector code. While the MuleSoft SDK has a built-in mechanism to automatically refresh expired OAuth access tokens, your code was bypassing it. Your IDPConnection class was explicitly retrieving the token and manually adding it to the Authorization header of each HTTP request. This prevented the SDK's internal HttpClient from recognizing when a token had expired and from performing the necessary "refresh dance" to acquire a new one. Consequently, after one hour (the token's expiration time), all subsequent API calls would fail with a 401 Unauthorized error because they were still using the invalid token.

The solution was to refactor your code to let the MuleSoft SDK's HttpClient handle the token lifecycle. Instead of manually retrieving the access token and constructing the Authorization header, the code should be changed to use the HttpAuthentication object within the HttpRequestOptions. This allows the SDK to manage the token's state, automatically check for expiration, and initiate a new token request when needed. This change aligns your connector with the MuleSoft SDK's intended design for OAuth 2.0, ensuring that the token refresh process happens seamlessly and automatically in the background, resolving the 401 Unauthorized errors without requiring manual intervention in your code.